### PR TITLE
[feature] use librarian-puppet-maestrodev fork, which includes several

### DIFF
--- a/vagrant-librarian-puppet.gemspec
+++ b/vagrant-librarian-puppet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "librarian-puppet"
+  spec.add_runtime_dependency "librarian-puppet-maestrodev"
   spec.add_runtime_dependency "librarian"
   spec.add_runtime_dependency "puppet"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Fixes for various issues not found in vagrant-librarian.  Without this
puppetlabs/apache will not install from forge.puppetlabs.com due to
version naming problems.
