### PR TITLE
Don't use librarian-puppet-maestrodev

### DIFF
--- a/vagrant-librarian-puppet.gemspec
+++ b/vagrant-librarian-puppet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "librarian-puppet-maestrodev"
+  spec.add_runtime_dependency "librarian-puppet"
   spec.add_runtime_dependency "librarian"
   spec.add_runtime_dependency "puppet"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
I saw @martyn switched from using the `librarian-puppet` to the `librarian-puppet-maestrodev` gem.
The latter's repo says:

> Since 0.9.11.6 this fork is no longer used, as I am committing directly to rodjek's librarian-puppet and pushing to librarian-puppet
> librarian-puppet-maestrodev 0.9.11.6 is effectively the same as librarian-puppet 0.9.11

As far as I understand the maintainer of the `-maestrodev`-fork is now committing to the original repo.
If there's a problem in `librarian-puppet` I think you should fix it upstream?

What do you think?
