### PR TITLE
Add support for librarian-puppet options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Vagrant.configure("2") do |config|
   config.librarian_puppet.puppetfile_dir = "puppet"
   # placeholder_filename defaults to .PLACEHOLDER
   config.librarian_puppet.placeholder_filename = ".MYPLACEHOLDER"
+  config.use_v1_api = '1'   # Check https://github.com/rodjek/librarian-puppet#how-to-use
+  config.destruct = false   # Check https://github.com/rodjek/librarian-puppet#how-to-use
 
   config.vm.provision :puppet do |puppet|
     puppet.module_path = "puppet/modules"

--- a/lib/vagrant-librarian-puppet/action/librarian_puppet.rb
+++ b/lib/vagrant-librarian-puppet/action/librarian_puppet.rb
@@ -1,5 +1,6 @@
 require 'librarian/puppet'
 require 'librarian/action'
+require "librarian/puppet/action/install"
 
 module VagrantPlugins
   module LibrarianPuppet
@@ -43,9 +44,12 @@ module VagrantPlugins
             environment = Librarian::Puppet::Environment.new({
               :project_path => File.join(env[:root_path], config.puppetfile_dir)
             })
+            environment.config_db.local['destructive']  = config.destructive.to_s
+            environment.config_db.local['use-v1-api']   = config.use_v1_api
+
             Librarian::Action::Ensure.new(environment).run
             Librarian::Action::Resolve.new(environment, config.resolve_options).run
-            Librarian::Action::Install.new(environment).run
+            Librarian::Puppet::Action::Install.new(environment).run
 
             # Restore the original path
             ENV['PATH'] = original_path

--- a/lib/vagrant-librarian-puppet/config.rb
+++ b/lib/vagrant-librarian-puppet/config.rb
@@ -2,12 +2,16 @@ module VagrantPlugins
   module LibrarianPuppet
     class Config < Vagrant.plugin(2, :config)
       attr_accessor :puppetfile_dir
+      attr_accessor :use_v1_api
+      attr_accessor :destructive
       attr_accessor :placeholder_filename
       attr_accessor :resolve_options
 
       def initialize
         @puppetfile_dir = UNSET_VALUE
         @placeholder_filename = UNSET_VALUE
+        @use_v1_api = UNSET_VALUE
+        @destructive = UNSET_VALUE
         @resolve_options = UNSET_VALUE
       end
 
@@ -15,6 +19,8 @@ module VagrantPlugins
         @puppetfile_dir = '.' if @puppetfile_dir == UNSET_VALUE
         @placeholder_filename = '.PLACEHOLDER' if @placeholder_filename == UNSET_VALUE
         @resolve_options = {} if @resolve_options == UNSET_VALUE
+        @use_v1_api = '1' if @use_v1_api == UNSET_VALUE
+        @destructive = true if @destructive == UNSET_VALUE
       end
 
       def validate(machine)
@@ -28,6 +34,15 @@ module VagrantPlugins
       def puppetfile_path
         @puppetfile_path ||= @puppetfile_dir ? File.join(@puppetfile_dir, 'Puppetfile') : 'Puppetfile'
       end
+
+      def use_v1_api
+        @use_v1_api ||= '1'
+      end
+
+      def destruct
+        @destruct ||= true
+      end
+
 
     end
   end

--- a/lib/vagrant-librarian-puppet/version.rb
+++ b/lib/vagrant-librarian-puppet/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module LibrarianPuppet
-    VERSION = "0.7.1"
+    VERSION = "0.7.2"
   end
 end


### PR DESCRIPTION
Added support for librarian-puppet options:
- use_v1_api
- destructive

This makes the plugin behave more like the regular version of librarian-puppet