### PR TITLE
bump librarian-puppet gem version to ~> 2.2.1

### DIFF
--- a/vagrant-librarian-puppet.gemspec
+++ b/vagrant-librarian-puppet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "librarian-puppet", "~> 2.0.1"
+  spec.add_runtime_dependency "librarian-puppet", "~> 2.2.1"
   # puppet_forge (all versions up to this date) have a dep on her ~> 0.6,
   # her >= 0.7.3 pulls in activemodel 4.2,
   # which pulls in i18n ~> 0.7,


### PR DESCRIPTION
To resolve this error that occurs with any forge module that has
dependency constraints:

    /home/jhoblitt/.vagrant.d/gems/gems/librarian-0.1.2/lib/librarian/dependency.rb:149:in
    `assert_name_valid!': name (nil) must be sensible (ArgumentError)
            from
    /home/jhoblitt/.vagrant.d/gems/gems/librarian-puppet-2.0.1/lib/librarian/puppet/extension.rb:14:in
    `initialize'
    ...

resolves #37
resolves #42 