### PR TITLE
Use system installed "puppet" binary

### DIFF
--- a/lib/vagrant-librarian-puppet/action/librarian_puppet.rb
+++ b/lib/vagrant-librarian-puppet/action/librarian_puppet.rb
@@ -16,21 +16,11 @@ module VagrantPlugins
         def call(env)
           config = env[:machine].config.librarian_puppet
           if provisioned?
-            # NB: Librarian::Puppet::Environment calls `which puppet` so we
-            # need to make sure VAGRANT_HOME/gems/bin has been added to the
-            # path.
-            original_path = ENV['PATH']
-            bin_path = env[:gems_path].join('bin')
-            ENV['PATH'] = "#{bin_path}#{::File::PATH_SEPARATOR}#{ENV['PATH']}"
-
             puppetfile_dirs = config.puppetfile_dir.kind_of?(Array) ? config.puppetfile_dir : [config.puppetfile_dir]
 
             puppetfile_dirs.each do |puppetfile_dir|
               provision(puppetfile_dir, env, config)
             end
-
-            # Restore the original path
-            ENV['PATH'] = original_path
           end
           @app.call(env)
         end


### PR DESCRIPTION
I suggest to use the `puppet` binary on the user/system's PATH, instead of the one installed with the puppet gem.

Both Puppetlabs and librarian-puppet recommend installing puppet with the provided installer packages, and not with rubygems:
https://github.com/rodjek/librarian-puppet/issues/38
https://docs.puppetlabs.com/puppet/3.8/reference/install_gem.html

This will allow the user to use the puppet version he wants to use.

Additionally it avoids problems with mixing GEM_HOMEs between system ruby, vagrant and vagrant-librarian-puppet (only when running `bundle exec vagrant` in the repo?).

@mhahn wdyt?
