### PR TITLE
Fix to work with directory environments

### DIFF
--- a/lib/vagrant-librarian-puppet/action/librarian_puppet.rb
+++ b/lib/vagrant-librarian-puppet/action/librarian_puppet.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
             placeholder_file = File.join(
               env[:root_path],
               puppetfile_dir,
-              'modules',
+              config.modules_dirname,
               config.placeholder_filename
             )
             if File.exist? placeholder_file
@@ -58,6 +58,7 @@ module VagrantPlugins
             })
             environment.config_db.local['destructive']  = config.destructive.to_s
             environment.config_db.local['use-v1-api']   = config.use_v1_api
+            environment.config_db.local['path']         = config.modules_dirname
 
             Librarian::Action::Ensure.new(environment).run
             Librarian::Action::Resolve.new(environment, config.resolve_options).run

--- a/lib/vagrant-librarian-puppet/config.rb
+++ b/lib/vagrant-librarian-puppet/config.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
       attr_accessor :destructive
       attr_accessor :placeholder_filename
       attr_accessor :resolve_options
+      attr_accessor :modules_dirname
 
       def initialize
         @puppetfile_dir = UNSET_VALUE
@@ -13,6 +14,7 @@ module VagrantPlugins
         @use_v1_api = UNSET_VALUE
         @destructive = UNSET_VALUE
         @resolve_options = UNSET_VALUE
+        @modules_dirname = UNSET_VALUE
       end
 
       def finalize!
@@ -21,6 +23,7 @@ module VagrantPlugins
         @resolve_options = {} if @resolve_options == UNSET_VALUE
         @use_v1_api = '1' if @use_v1_api == UNSET_VALUE
         @destructive = true if @destructive == UNSET_VALUE
+        @modules_dirname = 'modules' if @modules_dirname = UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
This change fixes the plugin to work with directory environments.

It seems that the modules dir was hard-coded to `modules` in the `placeholder_file` path so I've used that as the default for the modules_dirname config item and changed the `placeholder_file` to use it.
